### PR TITLE
Change `cfts_by_issuer` API

### DIFF
--- a/XLS-0033d-CFTs/README.md
+++ b/XLS-0033d-CFTs/README.md
@@ -619,7 +619,8 @@ Specify a limit to the number of CFTs returned.
              "OutstandingAmount": ....,
              "LockedAmount": .....,
              "TransferFee": .....,
-             "CFTokenMetadata": ....
+             "CFTokenMetadata": ....,
+             "ledger_index": 11231
            }
         ],
         "validated": true

--- a/XLS-0033d-CFTs/README.md
+++ b/XLS-0033d-CFTs/README.md
@@ -632,7 +632,7 @@ Specify a limit to the number of CFTs returned.
 |-------------------|:---------:|
 | `cft_issuances`   | `array`   |
 
-An array of CFTokenIssuance objects created by the specified account. Includes all fields in the underlying object, `ledger_index` for the index at which this CFT was created and `deleted_ledger_index` for the index at which this CFT was deleted (if applicable).
+An array of CFTokenIssuance objects created by the specified account. Includes all fields in the existing underlying object. For a deleted object, only `CFTokenIssuanceID` and `deleted_ledger_index` for the index at which this CFT was deleted are shown.
 
 | Field Name        | JSON Type |
 |-------------------|:---------:|

--- a/XLS-0033d-CFTs/README.md
+++ b/XLS-0033d-CFTs/README.md
@@ -631,7 +631,7 @@ Specify a limit to the number of CFTs returned.
 |-------------------|:---------:|
 | `cft_issuances`   | `array`   |
 
-An array of CFTokenIssuance objects created by the specified account. Includes all fields in the existing underlying object. For a deleted object, only `CFTokenIssuanceID` and `deleted_ledger_index` for the index at which this CFT was deleted are shown.
+An array of CFTokenIssuance objects created by the specified account. Includes all fields in the existing underlying object, `ledger_index` for the index at which this CFT was last modified.  For a deleted object, only `CFTokenIssuanceID` and `deleted_ledger_index` for the index at which this CFT was deleted are shown.
 
 | Field Name        | JSON Type |
 |-------------------|:---------:|

--- a/XLS-0033d-CFTs/README.md
+++ b/XLS-0033d-CFTs/README.md
@@ -619,8 +619,7 @@ Specify a limit to the number of CFTs returned.
              "OutstandingAmount": ....,
              "LockedAmount": .....,
              "TransferFee": .....,
-             "CFTokenMetadata": ....,
-             "ledger_index": 11231
+             "CFTokenMetadata": ....
            }
         ],
         "validated": true


### PR DESCRIPTION
- Fixed `ledger_index` to make it show the last modified ledger 
- Deleted `CFTokenIssuances` no longer need to display full data info, since it can be cumbersome to implement and not much incentive as users probably don't care about the info for deleted CFTs. If they really want to see deleted CFT info, they can use `deleted_ledger_index` to query for the state of CFT at the time of deletion, using `ledger_entry` API.