### PR TITLE
Improve contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,8 @@ Assuming there is consensus to publish, one of the project maintainers will revi
 
 A _Candidate Specification_ is a document that was previously a Draft, but is considered stable enough by the community such that no further changes are required. Once an XLS becomes a Candidate Specification, no further substantive changes are allowed under the same XLS number.
 
+Refinements in detail are still allowed and recommended. For example, you can clarify exact error cases and define the error codes and transaction result codes that occur in those cases.
+
 ##### Publishing a Candidate Specification
 
 When a Draft is considered stable, there is a call for review from the community to publish the document as a Candidate Specification by making a PR to remove the `d` from the document folder name and update the `type` to `candidate-specification`.

--- a/xls-template.md
+++ b/xls-template.md
@@ -81,9 +81,9 @@ The following is an example of how you can document new transactions, ledger ent
 
 <Any explanatory text about specific flags>
 
-For "Internal Type, most fields should use existing types defined in the XRPL binary format's type list here: https://xrpl.org/docs/references/protocol/binary-format#type-list . If a new type must be defined, add a separate section describing the rationale for the type, its binary format, and JSON representation.
+For "Internal Type", most fields should use existing types defined in the XRPL binary format's type list here: https://xrpl.org/docs/references/protocol/binary-format#type-list . If a new type must be defined, add a separate section describing the rationale for the type, its binary format, and JSON representation.
 
-For cases of transaction definitions, note any error cases that can occur. If the transaction can fail with a tec-class result code, specify which code to use. (Since tec codes are immutable data recorded in the ledger, changing them can render previous data incompatible with the current implementation. Also, tec codes are finite and limited, so it's best to reuse existing codes where appropriate.) Details of error codes can be vague or incomplete at first, but should be refined as the proposal moves through the candidate specification process.
+When defining transactions, please identify any potential error scenarios. If a transaction can fail with a `tec`-class result code, specify the appropriate code. Remember that tec codes are immutable ledger entries, so changing them can cause compatibility issues with older data. Additionally, as tec codes are limited in number, it's best to reuse existing codes whenever possible. While error code details may be initially vague or incomplete, they should be refined as the proposal progresses through the candidate specification process.
 -->
 
 ## Rationale
@@ -129,7 +129,7 @@ No backward compatibility issues found.
 <!--
   This section is optional, but recommended.
 
-  Invariants are rules for a feature's behavior that should never be broken, which define the borders of normal behavior and the assumptions involved in the design. If a situation violates an invariant, then it can be identified as unintended behavior; this helps to catch and prevent bugs. Code for the XRP Ledger includes invariant checks, which can prevent a transaction from executing if it would otherwise violate an invariant rule, preventing buggy or corrupted data from becoming part of the XRP Ledger's immutable history. The invariants defined here can be used to create invariant checks, although this spec can include invariants that are impractical to check at runtime.
+Invariants are fundamental rules governing a feature's behavior that must always hold true. They define the boundaries of expected behavior and the underlying assumptions of the design. If a situation violates an invariant, it can be classified as unintended behavior, aiding in bug detection and prevention. The XRP Ledger's code incorporates invariant checks to prevent transactions from executing if they would violate an invariant rule, thereby safeguarding the ledger's immutable history from erroneous or corrupted data. While the invariants specified here can be used to create invariant checks, some may be impractical to verify at runtime.
 
   TODO: Remove this comment before submitting
 

--- a/xls-template.md
+++ b/xls-template.md
@@ -55,9 +55,9 @@ core_protocol_changes_required: <true/false> # Indicates whether the proposal re
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
 <!--
-The following is an example of how you can document new object types and fields:
+The following is an example of how you can document new transactions, ledger entry types, and fields:
 
-#### The **`<object name>`** object
+#### **`<entry name>`** ledger entry
 
 <High level overview, explaining the object>
 
@@ -71,7 +71,7 @@ The following is an example of how you can document new object types and fields:
 |-------------------|:----------------:|:---------------:|:-----------------:|
 | `<field name>` | :heavy_check_mark: | `<string, number, object, array, boolean>` | `<UINT128, UINT160, UINT256, ...>` |
 
-<Any explanatory text about specific fields>
+<Any explanatory text about specific fields. For example, if an object must contain exactly one of three fields, note that here.>
 
 ###### Flags
 
@@ -80,6 +80,10 @@ The following is an example of how you can document new object types and fields:
 >| `lsf<flag name>` | `0x0001`| <flag description> |
 
 <Any explanatory text about specific flags>
+
+For "Internal Type, most fields should use existing types defined in the XRPL binary format's type list here: https://xrpl.org/docs/references/protocol/binary-format#type-list . If a new type must be defined, add a separate section describing the rationale for the type, its binary format, and JSON representation.
+
+For cases of transaction definitions, note any error cases that can occur. If the transaction can fail with a tec-class result code, specify which code to use. (Since tec codes are immutable data recorded in the ledger, changing them can render previous data incompatible with the current implementation. Also, tec codes are finite and limited, so it's best to reuse existing codes where appropriate.) Details of error codes can be vague or incomplete at first, but should be refined as the proposal moves through the candidate specification process.
 -->
 
 ## Rationale
@@ -118,6 +122,17 @@ No backward compatibility issues found.
   If the test suite is too large to reasonably be included inline, then consider adding it as one or more files in the folder with this XLS. External links are discouraged.
 
   TODO: Remove this comment before submitting
+-->
+
+## Invariants
+
+<!--
+  This section is optional, but recommended.
+
+  Invariants are rules for a feature's behavior that should never be broken, which define the borders of normal behavior and the assumptions involved in the design. If a situation violates an invariant, then it can be identified as unintended behavior; this helps to catch and prevent bugs. Code for the XRP Ledger includes invariant checks, which can prevent a transaction from executing if it would otherwise violate an invariant rule, preventing buggy or corrupted data from becoming part of the XRP Ledger's immutable history. The invariants defined here can be used to create invariant checks, although this spec can include invariants that are impractical to check at runtime.
+
+  TODO: Remove this comment before submitting
+
 -->
 
 ## Reference Implementation


### PR DESCRIPTION
Encourage discussion of invariants and error codes during the spec phase.

Some of these are based on learnings from the AMM spec and process: error codes there were changed several times during development, which led to confusion and mismatches between code, docs, and devnet as there were sometimes delays in updating any one of those with the latest changes. Also, some of the bugs in the AMM v1 implementation could have been avoided if invariants and invariant checks had been defined and implemented earlier on.

Also, `tec`-class transaction result codes are very limited, with values from 100 to 255 inclusive, and roughly a third of the existing codes have been added to the main codebase in the past 13 months, which puts us on track to run out of new `tec` codes fairly soon unless we make better efforts to conserve and reuse them. Therefore, I've added some notes which should hopefully help raise these discussions earlier in the process when changes are easier to make.

