### PR TITLE
Set the GITHUB_PAGES_BASE_URL environment variable to an empty string…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,6 +43,8 @@ jobs:
 
       - name: Build site
         run: python site/build_site.py
+        env: 
+          GITHUB_PAGES_BASE_URL: ""
 
       - name: Setup Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
… to generate root-relative paths for the custom domain.