### PR TITLE
XLS-0085: align MPT lock error code with implementation (tecFROZEN -> tecLOCKED)

### DIFF
--- a/XLS-0085-token-escrow/README.md
+++ b/XLS-0085-token-escrow/README.md
@@ -68,7 +68,7 @@ The `EscrowCreate` transaction is modified as follows:
   - **MPTs**: If the source does not hold the MPT, the transaction fails with `tecOBJECT_NOT_FOUND`.
 
 - **Source Account is Frozen or Token is Locked:**
-  - If the token is frozen (global/individual/deepfreeze) (IOU) or locked (MPT) for the source, the transaction fails with `tecFROZEN`.
+  - If the token is frozen (global/individual/deepfreeze) (IOU) for the source, the transaction fails with `tecFROZEN`. If the token is locked (MPT) for the source, the transaction fails with `tecLOCKED`.
 
 - **Insufficient Spendable Balance:**
   - If the source account lacks sufficient spendable balance, the transaction fails with `tecUNFUNDED`.
@@ -104,7 +104,7 @@ The `EscrowCreate` transaction is modified as follows:
     - **Deep Freeze**: If the token is deep frozen, the transaction fails with `tecFROZEN`.
     - **Global/Individual Freeze**: The transaction succeeds despite the token being globally or individually frozen.
   - **MPTs**:
-    - **Lock Conditions (Equivalent to Deep Freeze)**: Transaction fails with `tecFROZEN`.
+    - **Lock Conditions (Equivalent to Deep Freeze)**: Transaction fails with `tecLOCKED`.
 
 **State Changes:**
 


### PR DESCRIPTION
Documentation only change for XLS-0085 (Token Escrow, status Final).

The spec currently says EscrowCreate and EscrowFinish fail with `tecFROZEN` when an MPT is locked, but the rippled implementation returns `tecLOCKED` in those cases. `tecLOCKED` is the consistent codebase wide convention for locked MPTs (see `TokenHelpers.cpp`, which branches `asset.holds<MPTIssue>() ? tecLOCKED : tecFROZEN`, plus the payment, check and escrow paths).

This PR aligns the two affected failure condition entries with the implementation:

- EscrowCreate, "Source Account is Frozen or Token is Locked": split into the IOU case (`tecFROZEN`) and the MPT lock case (`tecLOCKED`)
- EscrowFinish, MPT "Lock Conditions (Equivalent to Deep Freeze)": `tecFROZEN` -> `tecLOCKED`

Happy to close this if maintainers prefer changing the code side instead; the linked issue tracks that question.


Fixes #600