### PR TITLE
XLS-66: Clarify `CoverRateMinimum` units in the `LoanBrokerSet` fields table

### DIFF
--- a/XLS-0066-lending-protocol/README.md
+++ b/XLS-0066-lending-protocol/README.md
@@ -560,7 +560,7 @@ The transaction creates a new `LoanBroker` object or updates an existing one.
 | `Data`                 |    No    | `string`  |    `BLOB`     |     None      | Arbitrary metadata in hex format. The field is limited to 256 bytes.                                                                               |
 | `ManagementFeeRate`    |    No    | `number`  |   `UINT16`    |       0       | The 1/10th basis point fee charged by the Lending Protocol Owner. Valid values are between 0 and 10000 inclusive (1% - 10%).                       |
 | `DebtMaximum`          |    No    | `string`  |   `NUMBER`    |       0       | The maximum amount the protocol can owe the Vault. The default value of 0 means there is no limit to the debt. Must not be negative.               |
-| `CoverRateMinimum`     |    No    | `number`  |   `UINT32`    |       0       | The 1/10th basis point `DebtTotal` that the first-loss capital must cover. Valid values are between 0 and 100000 inclusive.                        |
+| `CoverRateMinimum`     |    No    | `number`  |   `UINT32`    |       0       | The minimum first-loss capital coverage, expressed in 1/10th basis points and applied to `DebtTotal`. Valid values are between 0 and 100000 inclusive. |
 | `CoverRateLiquidation` |    No    | `number`  |   `UINT32`    |       0       | The 1/10th basis point of minimum required first-loss capital liquidated to cover a Loan default. Valid values are between 0 and 100000 inclusive. |
 
 #### 3.3.2 Transaction Fee


### PR DESCRIPTION
## High Level Overview of Change

Wording fix in the `LoanBrokerSet` fields table of XLS-66. The `CoverRateMinimum` description reads "The 1/10th basis point `DebtTotal` that the first-loss capital must cover", which is ungrammatical and also reads as if `DebtTotal` were itself denominated in basis points. It now reads as a minimum coverage expressed in 1/10th basis points and applied to `DebtTotal`.

No behavioural change to the specification. The valid range (0 to 100000 inclusive) is unchanged.

### Context of Change

Split out of #497. That PR proposes making `VaultID` conditional on `LoanBrokerSet`; this unrelated wording fix had been folded into it by mistake and is raised separately here so #497 carries only its own proposal.

### Type of Change

- [ ] New XLS Draft
- [ ] XLS Update (changes to an existing XLS)
- [ ] XLS Status Change (e.g., Draft → Final, Draft → Stagnant)
- [ ] Process/Meta (changes to CONTRIBUTING.md, XLS-1, templates, etc.)
- [ ] Infrastructure (CI, workflows, scripts, website)
- [x] Documentation (README updates, typo fixes)
