### PR TITLE
chore: replace .claude/skills symlinks with pointer stubs

### DIFF
--- a/.claude/skills/spec-from-rippled
+++ b/.claude/skills/spec-from-rippled
@@ -1,1 +1,0 @@
-../../.agents/skills/spec-from-rippled

--- a/.claude/skills/spec-from-rippled/SKILL.md
+++ b/.claude/skills/spec-from-rippled/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: spec-from-rippled
+description: Update an XLS specification to match changes made in rippled. Use when asked to sync a spec with a rippled PR or commit, update an XLS from the implementation, reconcile a spec against rippled code, or check whether a spec still matches what was built.
+---
+
+Read `.agents/skills/spec-from-rippled/SKILL.md` from the repository root and follow it. That file is the whole skill; this one only makes it discoverable to Claude Code.

--- a/.claude/skills/xls-template-conformity
+++ b/.claude/skills/xls-template-conformity
@@ -1,1 +1,0 @@
-../../.agents/skills/xls-template-conformity

--- a/.claude/skills/xls-template-conformity/SKILL.md
+++ b/.claude/skills/xls-template-conformity/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: xls-template-conformity
+description: Check that an XLS specification conforms to the XRPL-Standards templates. Use when asked to check an XLS against the template, validate a spec's structure or preamble, review a draft's format before opening a PR, or review changes to an XLS-*/README.md file.
+---
+
+Read `.agents/skills/xls-template-conformity/SKILL.md` from the repository root and follow it. That file is the whole skill; this one only makes it discoverable to Claude Code.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,7 +26,7 @@ This repository is the canonical home for **XRP Ledger Standards (XLSes)** — s
 ├── .agents/skills/         # Agent Skills, shared across Cursor/Codex/Gemini/Augment/Claude
 │   ├── xls-template-conformity/  # Check an XLS against the templates
 │   └── spec-from-rippled/        # Update a spec from rippled code changes
-├── .claude/skills/         # Symlinks into .agents/skills (Claude Code only scans .claude)
+├── .claude/skills/         # Stubs pointing into .agents/skills (Claude Code only scans .claude)
 ├── .ai-review/
 │   └── instructions.md     # Symlink to .github/copilot-instructions.md (Ripple review bot)
 └── .github/
@@ -214,16 +214,17 @@ Guidance for AI agents is spread across several files because each tool discover
 | `.ai-review/instructions.md`          | Ripple `@ai-review` bot                 | Symlink to the above                            |
 | `.github/skills/code-review/SKILL.md` | Copilot code review                     | Real file (Copilot does not resolve symlinks)   |
 | `.agents/skills/<name>/SKILL.md`      | Cursor, Codex CLI, Gemini CLI, Augment  | Real files — edit here                          |
-| `.claude/skills/<name>`               | Claude Code                             | Symlinks to `.agents/skills/<name>`             |
+| `.claude/skills/<name>/SKILL.md`      | Claude Code                             | Stub — frontmatter plus a pointer to the above  |
 | `.gitignore` (AI section)             | —                                       | Keeps per-developer agent state out of the repo |
 
 Rules of thumb:
 
-- **Adding a skill?** Create it under `.agents/skills/<name>/`, then add the matching symlink in `.claude/skills/`. Without the symlink, Claude Code cannot see it.
-- **Adding a new agent tool to the team's rotation?** Add its discovery path here, symlinked to the existing skill rather than copied.
+- **Adding a skill?** Create it under `.agents/skills/<name>/`, then add a stub `.claude/skills/<name>/SKILL.md` that repeats the `name` and `description` frontmatter and points at the real file. Without the stub, Claude Code cannot see it.
+- **Adding a new agent tool to the team's rotation?** Add its discovery path here, pointing at the existing skill rather than copying it.
+- **Do not use symlinks for skills.** GitHub Copilot code review aborts skill loading when a path under a skills directory links outside it, and drops _every_ skill in the repository — including `.github/skills/code-review/`.
 - **Changing a review rule?** It belongs in the Review Guidelines section above. `.github/skills/code-review/SKILL.md` intentionally repeats the critical completion, suppression, and "never flag" rules because Copilot may not follow the link out of it — keep that short duplication in sync deliberately.
 - **Changing a skill's procedure?** Skills read `templates/` and run `scripts/validate_xls_template.py` at run time on purpose. Keep it that way: a skill that restates the templates will drift from them.
-- Symlinks are committed at git mode `120000`. Some tools render them as one-line files containing a path, or omit them entirely. That is expected — do not "fix" them into copies.
+- `.ai-review/instructions.md` is committed as a symlink at git mode `120000`. Some tools render it as a one-line file containing a path, or omit it entirely. That is expected — do not "fix" it into a copy.
 
 ## Known Gotchas
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,7 +33,7 @@ Please check [x] relevant options, delete irrelevant ones.
 If this PR changes templates/, the validation scripts, the XLS process, or any
 AI instruction file, confirm the AI guidance still describes them correctly:
 .github/copilot-instructions.md, .github/skills/, and .agents/skills/ (plus the
-.claude/skills symlinks). See CONTRIBUTING.md section 8.3.
+.claude/skills stubs). See CONTRIBUTING.md section 8.3.
 -->
 
 <!--

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -43,4 +43,4 @@ Read existing review threads before submitting the review. Do not repeat an issu
 
 `.ai-review/instructions.md` is a committed symlink (git mode `120000`). If your view of the tree does not resolve it, it will look absent or look like a one-line file containing a path. Do not report it as missing or malformed.
 
-The `.claude/skills/<name>/SKILL.md` files are deliberately one-line stubs that point at `.agents/skills/<name>/SKILL.md`. Do not report them as incomplete.
+The `.claude/skills/<name>/SKILL.md` files are deliberate stubs: `name` and `description` frontmatter, which Claude Code needs to discover the skill, plus one line pointing at `.agents/skills/<name>/SKILL.md`, which holds the procedure. Do not report them as incomplete, and do not propose removing the frontmatter.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -41,4 +41,6 @@ Read existing review threads before submitting the review. Do not repeat an issu
 
 ## Note on symlinks
 
-`.ai-review/instructions.md`, `.claude/skills/xls-template-conformity`, and `.claude/skills/spec-from-rippled` are committed symlinks (git mode `120000`). If your view of the tree does not resolve them, they will look absent or look like one-line files containing a path. Do not report them as missing or malformed.
+`.ai-review/instructions.md` is a committed symlink (git mode `120000`). If your view of the tree does not resolve it, it will look absent or look like a one-line file containing a path. Do not report it as missing or malformed.
+
+The `.claude/skills/<name>/SKILL.md` files are deliberately one-line stubs that point at `.agents/skills/<name>/SKILL.md`. Do not report them as incomplete.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,15 +165,15 @@ Two skills live under `.agents/skills/`:
 | `xls-template-conformity` | Checks an XLS against `templates/` and the validation scripts, and reports what needs fixing.              |
 | `spec-from-rippled`       | Updates a spec to match a rippled PR, commit, or local branch, citing the implementation for every change. |
 
-Cursor, Codex CLI, Gemini CLI, and Augment discover `.agents/skills/` directly. Claude Code reads them through symlinks in `.claude/skills/`.
+Cursor, Codex CLI, Gemini CLI, and Augment discover `.agents/skills/` directly. Claude Code only scans `.claude/skills/`, so each skill has a stub `SKILL.md` there that carries the frontmatter and points at the real file.
 
 ### 8.3. Keep the guidance in sync
 
 Agent instructions are duplicated across paths because each tool looks in a different place. **If your PR changes one of these files, check the others in the same PR** — a stale copy teaches a reviewer the wrong rule, which is worse than no copy at all.
 
-[`.github/copilot-instructions.md` § Maintaining the AI instruction surface](./.github/copilot-instructions.md#maintaining-the-ai-instruction-surface) lists every file, which tool reads it, and which ones are symlinks. Start there. In short:
+[`.github/copilot-instructions.md` § Maintaining the AI instruction surface](./.github/copilot-instructions.md#maintaining-the-ai-instruction-surface) lists every file, which tool reads it, and how each one points at the others. Start there. In short:
 
-- Add a skill under `.agents/skills/<name>/`, and add the matching `.claude/skills/<name>` symlink.
+- Add a skill under `.agents/skills/<name>/`, and add the matching `.claude/skills/<name>/SKILL.md` stub. Do not use a symlink — Copilot code review drops every skill in the repository when it finds one under a skills directory.
 - Put review rules in the Review Guidelines section, not scattered across skills.
 - Skills read `templates/` and run `scripts/validate_xls_template.py` at run time rather than restating them, so that changing a template does not require changing a skill. Keep it that way.
 


### PR DESCRIPTION
## Summary

`.claude/skills/spec-from-rippled` and `.claude/skills/xls-template-conformity` were committed as symlinks into `.agents/skills/`. Copilot code review refuses to materialize a symlink under a skills directory whose target resolves outside it, and it drops **every** skill in the repository when it finds one:

```
[skills] Materialization aborted (symlink .claude/skills/spec-from-rippled target
"../../.agents/skills/spec-from-rippled" resolves to ".agents/skills/spec-from-rippled"
which escapes convention root); dropping all base-branch skills for safety.
[skills] session=github/copilot-code-review catalogEntries=0
```

That takes `.github/skills/code-review/SKILL.md` down with it, so Copilot has been reviewing PRs without the repo's review skill since #607.

Each `.claude/skills/<name>/SKILL.md` is now a real file: the `name` and `description` frontmatter Claude Code needs for discovery, plus one line pointing at `.agents/skills/<name>/SKILL.md`. The procedure stays in `.agents/` as the single source of truth — only the discovery metadata is repeated. `.ai-review/instructions.md` stays a symlink; it is not under a skills directory and Copilot reads the real `.github/copilot-instructions.md`.

## Type of change

- [x] Documentation (README updates, typo fixes)

## Test plan

- `pre-commit run --files <changed>` — passed (prettier, whitespace, EOF).
- `git ls-files -s .claude` — both entries are mode `100644`, no `120000` remains under a skills directory.
- Claude Code re-scanned `.claude/skills/` after the change and still lists both skills.
- Copilot's skill loading can only be confirmed from this PR's own review run: `[skills] ... catalogEntries` should be non-zero.
